### PR TITLE
 Add update-desktop-files as build requirement 

### DIFF
--- a/package/yast2-vpn.changes
+++ b/package/yast2-vpn.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 08:56:40 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:42:39 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-vpn.spec
+++ b/package/yast2-vpn.spec
@@ -27,6 +27,7 @@ Group:          System/YaST
 
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 4.2.2
+BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)

--- a/package/yast2-vpn.spec
+++ b/package/yast2-vpn.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vpn
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-vpn
 Source0:        %{name}-%{version}.tar.bz2


### PR DESCRIPTION
> - The recent fix in YaST RPM macros now updates the desktop files
> - The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
> - Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`

---

Originally fixed by @lslezak in https://github.com/yast/yast-instserver/pull/45