### PR TITLE
Write sysctl settings to /etc/sysctl.d

### DIFF
--- a/package/yast2-vpn.changes
+++ b/package/yast2-vpn.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct  4 14:26:08 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Write sysctl settings to a file under /etc/sysctl.d (jsc#SLE-9077).
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Aug 26 09:27:11 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-vpn.spec
+++ b/package/yast2-vpn.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vpn
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-vpn
 Source0:        %{name}-%{version}.tar.bz2
@@ -25,7 +25,8 @@ Summary:        A YaST module for configuring VPN gateway and clients
 License:        GPL-2.0
 Group:          System/YaST
 
-BuildRequires:  yast2
+# CFA::Sysctl
+BuildRequires:  yast2 >= 4.2.25
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings
@@ -33,7 +34,9 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 
 PreReq:         %fillup_prereq
-Requires:       yast2
+
+# CFA::Sysctl
+Requires:       yast2 >= 4.2.25
 Requires:       yast2-ruby-bindings
 
 BuildArch:      noarch


### PR DESCRIPTION
Adapts sysctl handling to use the new [CFA::Sysctl](https://github.com/yast/yast-yast2/pull/966) class so the configuration is written to a YaST specific file under `/etc/sysctl.d`.