### PR TITLE
Using SysctlConfig class: Handle sysctl entries in different directories

### DIFF
--- a/package/yast2-vpn.changes
+++ b/package/yast2-vpn.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 26 10:27:01 CET 2020 - schubi@suse.de
+
+- Using SysctlConfig class: Handle sysctl entries in different
+  directories (bsc#1151649).
+- 4.2.4
+
+-------------------------------------------------------------------
 Fri Oct  4 14:26:08 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Write sysctl settings to a file under /etc/sysctl.d (jsc#SLE-9077).

--- a/package/yast2-vpn.spec
+++ b/package/yast2-vpn.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vpn
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Url:            https://github.com/yast/yast-vpn
 Source0:        %{name}-%{version}.tar.bz2
@@ -25,8 +25,8 @@ Summary:        A YaST module for configuring VPN gateway and clients
 License:        GPL-2.0
 Group:          System/YaST
 
-# CFA::Sysctl
-BuildRequires:  yast2 >= 4.2.25
+# CFA::SysctlConfig
+BuildRequires:  yast2 >= 4.2.67
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings
@@ -35,8 +35,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 
 PreReq:         %fillup_prereq
 
-# CFA::Sysctl
-Requires:       yast2 >= 4.2.25
+# CFA::SysctlConfig
+Requires:       yast2 >= 4.2.67
 Requires:       yast2-ruby-bindings
 
 BuildArch:      noarch


### PR DESCRIPTION
**Problem**
Sysctl entries are stored in different files in different directories:
/run/sysctl.d,
/etc/sysctl.d
/usr/local/lib/sysctl.d
/usr/lib/sysctl.d
/lib/sysctl.d
/etc/sysctl.conf

General solution for it:
yast/yast-yast2#1021

**Solution**
Using SysctlConfig class.

**Testing**
Tested manually