### PR TITLE
Fixed issue where yast2-vpn breaks with strongswan

### DIFF
--- a/package/yast2-vpn.changes
+++ b/package/yast2-vpn.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  5 15:50:35 UTC 2023 - Mohd Saquib <mohd.saquib@suse.com>
+
+- Fixed an issue where yast2-vpn module breaks when strongswan is
+  updated to version >= 5.8.0 (boo#1176735)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-vpn.spec
+++ b/package/yast2-vpn.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vpn
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Url:            https://github.com/yast/yast-vpn
 Source0:        %{name}-%{version}.tar.bz2

--- a/src/lib/vpn/view_log_dialog.rb
+++ b/src/lib/vpn/view_log_dialog.rb
@@ -77,7 +77,7 @@ module VPN
                 _("Existing connections will be interrupted.\n" +
                     "Do you still wish to continue?")
                 )
-                if !(Yast::Service.Active("strongswan") ? Yast::Service.Restart("strongswan") : Yast::Service.Start("strongswan"))
+                if !(Yast::Service.Active("ipsec") ? Yast::Service.Restart("ipsec") : Yast::Service.Start("ipsec"))
                     Yast::Popup.Error(_("Failed to restart IPSec daemon"))
                 end
             end
@@ -90,7 +90,7 @@ module VPN
         private
         # Read daemon status and refresh the content of log views.
         def refresh_status
-            sh_daemon_status = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), "systemctl status strongswan")
+            sh_daemon_status = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), "systemctl status ipsec")
             Yast::UI.ChangeWidget(Id(:daemon_status), :Value, sh_daemon_status["stdout"])
 
             sh_conn_status = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), "ipsec statusall 2>&1")

--- a/src/modules/IPSecConf.rb
+++ b/src/modules/IPSecConf.rb
@@ -62,7 +62,7 @@ module Yast
             load_ipsec_conf_ini
             load_ipsec_secrets_ini
             # Read daemon settings
-            @enable_ipsec = Service.Enabled("strongswan")
+            @enable_ipsec = Service.Enabled("ipsec")
             customrules_content = get_customrules_txt
             @tcp_reduce_mss = customrules_content != nil && customrules_content.include?("--set-mss #{REDUCED_MSS}")
             @autoyast_modified = true
@@ -172,14 +172,14 @@ module Yast
             SCR.Write(path(".etc.ipsec_secrets"), nil)
             # Enable/disable daemon
             if @enable_ipsec
-                Service.Enable("strongswan")
-                if !(Service.Active("strongswan") ? Service.Restart("strongswan") : Service.Start("strongswan"))
+                Service.Enable("strongswan-starter")
+                if !(Service.Active("ipsec") ? Service.Restart("ipsec") : Service.Start("ipsec"))
                     Report.Error(_("Failed to start IPSec daemon."))
                     successful = false
                 end
             else
-                Service.Disable("strongswan")
-                Service.Stop("strongswan")
+                Service.Stop("ipsec")
+                Service.Disable("strongswan-starter")
             end
             # Configure IP forwarding
             sysctlconfig_modified = false


### PR DESCRIPTION
## Problem

*Short description of the original problem.*
yast2-vpn is currently broken with strongswan packages in SLE15 (all SPs) and Leap15.x + Tumbleweed
strongswan version < 5.8.0 used strongswan.service to use with ipsec interface with yast uses. Later versions
have moved to use strongswan-starter.service to use ipsec and strongswan.service is used for swanctl interface
Thus, with newer versions yast is still using the older systemd service file and causing breakage.

- *Bugzilla link*
https://bugzilla.suse.com/show_bug.cgi?id=1176735

## Solution

*Short description of the fix.*
Fix has been submitted to SLE15 (all SPs) + Factory --> https://build.opensuse.org/request/show/1077377
merging with the codestreams might take some time
but yast2-vpn needs to call the correct systemd service to work properly


## Testing

- *Tested manually*
Tested manually with the changes and yast2-vpn module is working correctly
